### PR TITLE
Round the bottom corners of the map window

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -706,7 +706,16 @@ img { display: block; max-width: 100%; }
 .map-dot { width: 12px; height: 12px; border-radius: 50%; box-shadow: inset 0 1px 1px rgba(255,255,255,.25); }
 .map-dot-close{ background:#ff5f56;} .map-dot-min{ background:#ffbd2e;} .map-dot-max{ background:#27c93f;}
 .map-title { font-size: .82rem; color: var(--text-muted); }
-.map-frame { position: relative; }
+/* The iframe paints on its own compositing layer (its filter forces this) and
+   slips past .map-window's rounded overflow clip, leaving square bottom corners.
+   Round and clip the iframe's own wrapper instead. Inner radius is the panel
+   radius minus the 1px window border so it tucks cleanly inside the frame. */
+.map-frame {
+    position: relative;
+    overflow: hidden;
+    border-bottom-left-radius: calc(var(--r-panel) - 1px);
+    border-bottom-right-radius: calc(var(--r-panel) - 1px);
+}
 .map-frame::before { content: ""; position: absolute; inset: 0; z-index: 1; pointer-events: none; background: linear-gradient(165deg, rgba(14,16,30,.42), rgba(8,9,13,.60)); mix-blend-mode: multiply; }
 .map-frame::after { content: ""; position: absolute; inset: 0; z-index: 2; pointer-events: none; box-shadow: inset 0 1px 0 0 var(--glass-border-lit); background: radial-gradient(120% 120% at 50% 0%, transparent 60%, rgba(127,178,255,.10), rgba(255,138,76,.07)); mix-blend-mode: screen; }
 .map-frame iframe { display: block; width: 100%; height: 420px; border: 0; filter: saturate(.72) contrast(.96) brightness(.62) hue-rotate(-6deg); }


### PR DESCRIPTION
## What this does

The location map sat in a window styled like a little macOS app, with a title bar and rounded corners. The top corners were rounded but the bottom two stayed square, so the frame looked unfinished.

## Why it happened

The embedded map is a Google Maps iframe, and we put a dark filter on it to match the theme. That filter pushes the iframe onto its own compositing layer, and a layer like that slips past the rounded `overflow: hidden` clip on the window around it. So the window border curved at the bottom while the map itself kept its square corners and poked through.

## The fix

Rounded and clipped the iframe's own wrapper instead of relying on the window to clip it. The radius is the panel radius minus the one pixel window border, so the map tucks cleanly inside the frame. I checked it on phone and desktop widths in both the dark and light themes, and all four corners match now.

Generated with Claude Code